### PR TITLE
Fix [QSP-7] forceTransmute does not check if msg.sender is a new user

### DIFF
--- a/contracts/Transmuter.sol
+++ b/contracts/Transmuter.sol
@@ -275,6 +275,7 @@ contract Transmuter is Context {
         runPhasedDistribution()
         updateAccount(msg.sender)
         updateAccount(toTransmute)
+        checkIfNewUser()
     {
         //load into memory
         address sender = msg.sender;


### PR DESCRIPTION
If a fresh address invokes forceTransmute, userList would not record the user address
Then user information cannot be retrieved by getMultipleUserInfo function
Append checkIfNewUser in the forceTransmute function to handle this