### PR TITLE
Accrue interest value for alpaca vault

### DIFF
--- a/contracts/adapters/AlpacaVaultAdapter.sol
+++ b/contracts/adapters/AlpacaVaultAdapter.sol
@@ -181,7 +181,7 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
       reservePool = reservePool.add(toReserve);
       vaultDebtVal = vaultDebtVal.add(interest);
     }
-    return busdToken.balanceOf(address(this)).add(vaultDebtVal).sub(reservePool);
+    return busdToken.balanceOf(address(vault)).add(vaultDebtVal).sub(reservePool);
   }
 
   /// @dev Return the pending interest that will be accrued in the next call.
@@ -191,7 +191,7 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
   function _pendingInterest(uint256 _value, uint256 _lastAccrueTime, uint256 _vaultDebtVal) internal view returns (uint256) {
     if (now > _lastAccrueTime) {
       uint256 timePass = now.sub(_lastAccrueTime);
-      uint256 balance = busdToken.balanceOf(address(this)).sub(_value);
+      uint256 balance = busdToken.balanceOf(address(vault)).sub(_value);
       uint256 ratePerSec = config.getInterestRate(_vaultDebtVal, balance);
       return ratePerSec.mul(_vaultDebtVal).mul(timePass).div(1e18);
     } else {

--- a/contracts/adapters/AlpacaVaultAdapter.sol
+++ b/contracts/adapters/AlpacaVaultAdapter.sol
@@ -8,6 +8,7 @@ import {IDetailedERC20} from "../interfaces/IDetailedERC20.sol";
 import {IVaultAdapterV2} from "../interfaces/IVaultAdapterV2.sol";
 import {IbBUSDToken} from "../interfaces/IbBUSDToken.sol";
 import {IAlpacaPool} from "../interfaces/IAlpacaPool.sol";
+import {IAlpacaVaultConfig} from "../interfaces/IAlpacaVaultConfig.sol";
 import {IUniswapV2Router01, IUniswapV2Router02} from "../interfaces/IUniswapV2Router.sol";
 
 /// @title AlpacaVaultAdapter
@@ -36,6 +37,9 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
   /// @dev busdToken
   IDetailedERC20 public busdToken;
 
+  /// @dev IAlpacaVaultConfig
+  IAlpacaVaultConfig public config;
+
   /// @dev The address which has admin control over this contract.
   address public admin;
 
@@ -48,13 +52,14 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
   /// @dev The router path to sell alpaca for BUSD
   address[] public path;
 
-  constructor(IbBUSDToken _vault, address _admin, IUniswapV2Router02 _uniV2Router, IAlpacaPool _stakingPool, IDetailedERC20 _alpacaToken, IDetailedERC20 _wBNBToken, uint256 _stakingPoolId) public {
+  constructor(IbBUSDToken _vault, address _admin, IUniswapV2Router02 _uniV2Router, IAlpacaPool _stakingPool, IDetailedERC20 _alpacaToken, IDetailedERC20 _wBNBToken, IAlpacaVaultConfig _config, uint256 _stakingPoolId) public {
     require(address(_vault) != address(0), "AlpacaVaultAdapter: vault address cannot be 0x0.");
     require(_admin != address(0), "AlpacaVaultAdapter: _admin cannot be 0x0.");
     require(address(_uniV2Router) != address(0), "AlpacaVaultAdapter: _uniV2Router cannot be 0x0.");
     require(address(_stakingPool) != address(0), "AlpacaVaultAdapter: _stakingPool cannot be 0x0.");
     require(address(_alpacaToken) != address(0), "AlpacaVaultAdapter: _alpacaToken cannot be 0x0.");
     require(address(_wBNBToken) != address(0), "AlpacaVaultAdapter: _wBNBToken cannot be 0x0.");
+    require(address(_config) != address(0), "AlpacaVaultAdapter: _config cannot be 0x0.");
 
     vault = _vault;
     admin = _admin;
@@ -62,6 +67,7 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
     stakingPool = _stakingPool;
     alpacaToken = _alpacaToken;
     wBNBToken = _wBNBToken;
+    config = _config;
     stakingPoolId = _stakingPoolId;
 
     updateApproval();
@@ -164,14 +170,42 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
     alpacaToken.safeApprove(address(uniV2Router), uint256(-1));
   }
 
+  /// @dev Computes the total token entitled to the token holders.
+  function _totalToken() internal view returns (uint256) {
+    uint256 vaultDebtVal = vault.vaultDebtVal();
+    uint256 reservePool = vault.reservePool();
+    uint256 lastAccrueTime = vault.lastAccrueTime();
+    if (now > lastAccrueTime) {
+      uint256 interest = _pendingInterest(0, lastAccrueTime, vaultDebtVal);
+      uint256 toReserve = interest.mul(config.getReservePoolBps()).div(10000);
+      reservePool = reservePool.add(toReserve);
+      vaultDebtVal = vaultDebtVal.add(interest);
+    }
+    return busdToken.balanceOf(address(this)).add(vaultDebtVal).sub(reservePool);
+  }
+
+  /// @dev Return the pending interest that will be accrued in the next call.
+  /// @param _value Balance value to subtract off address(this).balance when called from payable functions.
+  /// @param _lastAccrueTime Last timestamp to accrue interest.
+  /// @param _vaultDebtVal Debt value of the given vault.
+  function _pendingInterest(uint256 _value, uint256 _lastAccrueTime, uint256 _vaultDebtVal) internal view returns (uint256) {
+    if (now > _lastAccrueTime) {
+      uint256 timePass = now.sub(_lastAccrueTime);
+      uint256 balance = busdToken.balanceOf(address(this)).sub(_value);
+      uint256 ratePerSec = config.getInterestRate(_vaultDebtVal, balance);
+      return ratePerSec.mul(_vaultDebtVal).mul(timePass).div(1e18);
+    } else {
+      return 0;
+    }
+  }
+
   /// @dev Computes the number of tokens an amount of shares is worth.
   ///
   /// @param _sharesAmount the amount of shares.
   ///
   /// @return the number of tokens the shares are worth.
-
   function _sharesToTokens(uint256 _sharesAmount) internal view returns (uint256) {
-    return _sharesAmount.mul(vault.totalToken()).div(vault.totalSupply());
+    return _sharesAmount.mul(_totalToken()).div(vault.totalSupply());
   }
 
   /// @dev Computes the number of shares an amount of tokens is worth.
@@ -180,6 +214,6 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
   ///
   /// @return the number of shares the tokens are worth.
   function _tokensToShares(uint256 _tokensAmount) internal view returns (uint256) {
-    return _tokensAmount.mul(vault.totalSupply()).div(vault.totalToken());
+    return _tokensAmount.mul(vault.totalSupply()).div(_totalToken());
   }
 }

--- a/contracts/adapters/AlpacaVaultAdapter.sol
+++ b/contracts/adapters/AlpacaVaultAdapter.sol
@@ -171,6 +171,10 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
   }
 
   /// @dev Computes the total token entitled to the token holders.
+  ///
+  /// source from alpaca vault: https://bscscan.com/address/0x7C9e73d4C71dae564d41F78d56439bB4ba87592f
+  ///
+  /// @return total token.
   function _totalToken() internal view returns (uint256) {
     uint256 vaultDebtVal = vault.vaultDebtVal();
     uint256 reservePool = vault.reservePool();
@@ -185,9 +189,13 @@ contract AlpacaVaultAdapter is IVaultAdapterV2 {
   }
 
   /// @dev Return the pending interest that will be accrued in the next call.
+  ///
+  /// source from alpaca vault: https://bscscan.com/address/0x7C9e73d4C71dae564d41F78d56439bB4ba87592f
+  ///
   /// @param _value Balance value to subtract off address(this).balance when called from payable functions.
   /// @param _lastAccrueTime Last timestamp to accrue interest.
   /// @param _vaultDebtVal Debt value of the given vault.
+  /// @return pending interest.
   function _pendingInterest(uint256 _value, uint256 _lastAccrueTime, uint256 _vaultDebtVal) internal view returns (uint256) {
     if (now > _lastAccrueTime) {
       uint256 timePass = now.sub(_lastAccrueTime);

--- a/contracts/interfaces/IAlpacaVaultConfig.sol
+++ b/contracts/interfaces/IAlpacaVaultConfig.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.6.12;
+
+interface IAlpacaVaultConfig {
+  function getInterestRate(uint256 debt, uint256 floating) external view returns (uint256);
+
+  function getReservePoolBps() external view returns (uint256);
+}

--- a/contracts/interfaces/IbBUSDToken.sol
+++ b/contracts/interfaces/IbBUSDToken.sol
@@ -4,6 +4,12 @@ pragma solidity 0.6.12;
 import {IDetailedERC20} from "./IDetailedERC20.sol";
 
 interface IbBUSDToken is IDetailedERC20 {
+    function vaultDebtVal() external view returns (uint256);
+
+    function lastAccrueTime() external view returns (uint256);
+
+    function reservePool() external view returns (uint256);
+
     function deposit(uint256) external;
 
     function withdraw(uint256) external;

--- a/contracts/mocks/AlpacaVaultConfigMock.sol
+++ b/contracts/mocks/AlpacaVaultConfigMock.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.6.12;
+
+contract AlpacaVaultConfigMock {
+  function getInterestRate(uint256 debt, uint256 floating) external view returns (uint256) {
+    return 1;
+  }
+
+  function getReservePoolBps() external view returns (uint256) {
+    return 1;
+  }
+}

--- a/contracts/mocks/IbBUSDMock.sol
+++ b/contracts/mocks/IbBUSDMock.sol
@@ -13,6 +13,7 @@ contract IbBUSDMock is ERC20 {
 
     uint256 public vaultDebtVal;
     uint256 public reservePool;
+    uint256 public lastAccrueTime;
 
     IDetailedERC20 public token;
 

--- a/test/contracts/FormationV2.spec.ts
+++ b/test/contracts/FormationV2.spec.ts
@@ -16,6 +16,7 @@ import { YearnControllerMock } from "../../types/YearnControllerMock";
 import { IbBusdMock } from "../../types/IbBUSDMock";
 import { UniswapV2Mock } from "../../types/UniswapV2Mock";
 import { AlpacaStakingPoolMock } from "../../types/AlpacaStakingPoolMock";
+import { AlpacaVaultConfigMock } from "../../types/AlpacaVaultConfigMock";
 import { AlpacaVaultAdapter } from "../../types/AlpacaVaultAdapter";
 import { YearnVaultMock } from "../../types/YearnVaultMock";
 import { EllipsisPoolMock } from "../../types/EllipsisPoolMock";
@@ -38,6 +39,7 @@ let YearnControllerMockFactory: ContractFactory;
 let ibBUSDMockFactory: ContractFactory;
 let uniswapV2MockFactory: ContractFactory;
 let alpacaStakingPoolMock: ContractFactory;
+let alpacaVaultConfigMock: ContractFactory;
 let alpacaVaultAdapter: ContractFactory;
 let ellipsisPoolMockFactory: ContractFactory;
 let threeesPoolMockFactory: ContractFactory;
@@ -59,6 +61,7 @@ describe("FormationV2", () => {
     ibBUSDMockFactory = await ethers.getContractFactory("IbBUSDMock");
     uniswapV2MockFactory = await ethers.getContractFactory("UniswapV2Mock");
     alpacaStakingPoolMock = await ethers.getContractFactory("AlpacaStakingPoolMock");
+    alpacaVaultConfigMock = await ethers.getContractFactory("AlpacaVaultConfigMock");
     alpacaVaultAdapter = await ethers.getContractFactory("AlpacaVaultAdapter");
     ellipsisPoolMockFactory = await ethers.getContractFactory("EllipsisPoolMock");
     threeesPoolMockFactory = await ethers.getContractFactory("I3ESPoolMock");
@@ -1075,6 +1078,7 @@ describe("FormationV2", () => {
     let ibBusd: IbBusdMock;
     let uniswapV2: UniswapV2Mock;
     let alpacaStaking: AlpacaStakingPoolMock;
+    let alpacaVaultConfig: AlpacaVaultConfigMock;
     let adapter: AlpacaVaultAdapter;
     let formation: FormationV2;
     
@@ -1106,6 +1110,7 @@ describe("FormationV2", () => {
         alpaca.address,
         parseEther("1")
       )) as AlpacaStakingPoolMock;
+      alpacaVaultConfig = (await alpacaVaultConfigMock.connect(deployer).deploy()) as AlpacaVaultConfigMock;
       adapter = (await alpacaVaultAdapter.connect(deployer).deploy(
         ibBusd.address,
         await governance.getAddress(),
@@ -1113,6 +1118,7 @@ describe("FormationV2", () => {
         alpacaStaking.address,
         alpaca.address,
         wBnb.address,
+        alpacaVaultConfig.address,
         0
       )) as AlpacaVaultAdapter;
     });


### PR DESCRIPTION
Since totalToken value was wrong when call it before withdraw, it didn't add the interest.

In this PR, we calculate total token with accrued interest, the formula is from alpaca vault.